### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
+  - conda info -a
   - conda update --yes conda
   - conda create --yes -n condaenv python=2.7
-  - conda install --yes -n condaenv pip scipy==0.16.0 numpy==1.9.2
+  - conda install --yes -n condaenv pip scipy==0.17.0 numpy==1.10.4
   - source activate condaenv
   - pip install .
 

--- a/setup.py
+++ b/setup.py
@@ -64,13 +64,13 @@ setup(
     test_suite='tests',
     install_requires=[
         'matplotlib==1.4.3',
-        'numpy==1.9.2',
+        'numpy==1.10.4',
         'pandas==0.16.0',
         'psycopg2==2.6',
         'click==4.0',
         'pytest==2.7.0',
         'flake8==2.2.5',
-        'scipy==0.16.0'
+        'scipy==0.17.0'
     ],
     zip_safe=False
 )


### PR DESCRIPTION
Had to bump the version of numpy/scipy to get the build working against libgfortran.so.3 versus the missing libgfortran.so.1 dependency
